### PR TITLE
Add user identity util; improve notifications & chat

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-137dedbd'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.06l6oaf3vc8"
+    "revision": "0.r4bctud498o"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/AdoptionRequestDetails.tsx
+++ b/src/components/AdoptionRequestDetails.tsx
@@ -10,6 +10,7 @@ import {
 import { toast } from "react-hot-toast";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
+import { resolveUserIdentity } from "../utils/userIdentity";
 
 interface AdoptionRequestDetailsProps {
   requestId: number;
@@ -43,17 +44,49 @@ interface AdoptionRequest {
 }
 
 // Utility function to create adoption chat
+const isPostIdSchemaError = (error: { code?: string | null; message?: string | null; details?: string | null }) => {
+  if (!error) return false;
+  const text = `${error.message || ""} ${error.details || ""}`.toLowerCase();
+  return error.code === "23503" || (text.includes("post_id") && text.includes("foreign key"));
+};
+
+const insertNotificationWithFallback = async (payload: {
+  user_id: string;
+  type: string;
+  message: string;
+  created_at: string;
+  requester_id?: string;
+  link?: string;
+  post_id?: number;
+}) => {
+  const firstAttempt = await supabase.from("notifications").insert([payload]);
+  if (!firstAttempt.error) return null;
+
+  if (payload.post_id && isPostIdSchemaError(firstAttempt.error)) {
+    const withoutPostId = { ...payload };
+    delete withoutPostId.post_id;
+    const secondAttempt = await supabase
+      .from("notifications")
+      .insert([withoutPostId]);
+    return secondAttempt.error;
+  }
+
+  return firstAttempt.error;
+};
+
 const createAdoptionChat = async ({
   adopterId,
   ownerId,
   postId,
   adopterName,
+  ownerName,
   petName,
 }: {
   adopterId: string;
   ownerId: string;
   postId: number;
   adopterName: string;
+  ownerName?: string;
   petName?: string;
 }) => {
   const { data: existing, error: existingError } = await supabase
@@ -63,28 +96,54 @@ const createAdoptionChat = async ({
       specific_post_id: postId,
     });
   if (!existingError && existing && existing.length > 0) return existing[0].conversation_id;
-  const { data, error } = await supabase
+
+  const baseConversationPayload = {
+    title: adopterName || ownerName || "Chat",
+    adopter_name: adopterName,
+    owner_name: ownerName || "",
+    pet_name: petName,
+    is_group: false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+
+  let createResult = await supabase
     .from("conversations")
-    .insert([
-      {
-        title: adopterName,
-        post_id: postId,
-        adopter_name: adopterName,
-        owner_name: "",
-        pet_name: petName,
-        is_group: false,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      },
-    ])
+    .insert([{ ...baseConversationPayload, post_id: postId }])
     .select()
     .single();
-  if (error) throw error;
-  const conversationId = data.id;
-  await supabase.from("user_conversations").insert([
-    { user_id: adopterId, conversation_id: conversationId, joined_at: new Date().toISOString() },
-    { user_id: ownerId, conversation_id: conversationId, joined_at: new Date().toISOString() },
-  ]);
+
+  if (createResult.error && isPostIdSchemaError(createResult.error)) {
+    createResult = await supabase
+      .from("conversations")
+      .insert([baseConversationPayload])
+      .select()
+      .single();
+  }
+
+  if (createResult.error) throw createResult.error;
+
+  const conversationId = createResult.data.id;
+
+  const { error: membersError } = await supabase
+    .from("user_conversations")
+    .upsert(
+      [
+        {
+          user_id: adopterId,
+          conversation_id: conversationId,
+          joined_at: new Date().toISOString(),
+        },
+        {
+          user_id: ownerId,
+          conversation_id: conversationId,
+          joined_at: new Date().toISOString(),
+        },
+      ],
+      { onConflict: "user_id,conversation_id", ignoreDuplicates: true }
+    );
+
+  if (membersError) throw membersError;
   return conversationId;
 };
 
@@ -137,53 +196,23 @@ export const AdoptionRequestDetails: React.FC<AdoptionRequestDetailsProps> = ({
         // Fetch requester details
         if (requestData.requester_id) {
           try {
-            // First try to get user profile from the profiles table
-            const { data: profileData, error: profileError } = await supabase
+            const requesterIdentity = await resolveUserIdentity(
+              requestData.requester_id
+            );
+
+            const { data: profileData } = await supabase
               .from("profiles")
-              .select("id, full_name, avatar_url, location")
+              .select("avatar_url, location")
               .eq("id", requestData.requester_id)
               .maybeSingle();
 
-            if (!profileError && profileData) {
-              // Use profile data
-              setRequester({
-                id: profileData.id,
-                full_name: profileData.full_name || "Name not provided",
-                avatar_url: profileData.avatar_url,
-                location: profileData.location,
-                // We don't include email for privacy
-                email: "Contact via app messaging",
-              });
-            } else if (profileError && profileError.code === "42P01") {
-              // If profiles table doesn't exist, try to get user data directly
-              const { data: userData, error: userError } = await supabase.rpc(
-                "get_user_name",
-                { user_id: requestData.requester_id }
-              );
-
-              if (!userError && userData) {
-                // Use data from auth.users
-                setRequester({
-                  id: requestData.requester_id,
-                  full_name: userData || "User",
-                  email: "Contact via app messaging",
-                });
-              } else {
-                // Fallback to minimal info
-                setRequester({
-                  id: requestData.requester_id,
-                  full_name: "User",
-                  email: "Contact information not available",
-                });
-              }
-            } else {
-              // Fallback to minimal info
-              setRequester({
-                id: requestData.requester_id,
-                full_name: "User",
-                email: "Contact information not available",
-              });
-            }
+            setRequester({
+              id: requestData.requester_id,
+              full_name: requesterIdentity.name,
+              avatar_url: requesterIdentity.avatar || profileData?.avatar_url,
+              location: profileData?.location,
+              email: requesterIdentity.email || "Contact via app messaging",
+            });
           } catch (userError) {
             console.error("Error fetching user details:", userError);
             // Fallback to minimal info
@@ -233,6 +262,9 @@ export const AdoptionRequestDetails: React.FC<AdoptionRequestDetailsProps> = ({
 
       // If approved, also update post status to 'adopted'
       if (status === "approved") {
+        const requesterIdentity = await resolveUserIdentity(request.requester_id);
+        const ownerIdentity = await resolveUserIdentity(request.owner_id);
+
         // Change pet status to adopted
         const { error: postError } = await supabase
           .from("posts")
@@ -245,7 +277,8 @@ export const AdoptionRequestDetails: React.FC<AdoptionRequestDetailsProps> = ({
           adopterId: request.requester_id,
           ownerId: request.owner_id,
           postId: request.post_id,
-          adopterName: requester?.full_name || "Unknown",
+          adopterName: requesterIdentity.name,
+          ownerName: ownerIdentity.name,
           petName: request.post?.name,
         });
         toast.success("Adoption approved! Redirecting to chat...");
@@ -263,19 +296,15 @@ export const AdoptionRequestDetails: React.FC<AdoptionRequestDetailsProps> = ({
         request.post?.name || "the pet"
       } has been rejected.`;
 
-      const { error: notificationError } = await supabase
-        .from("notifications")
-        .insert([
-          {
-            user_id: request.requester_id,
-            type: `adoption_${status}`,
-            message,
-            read: false,
-            created_at: new Date().toISOString(),
-            link: `/post/${request.post_id}`,
-            post_id: request.post_id,
-          },
-        ]);
+      const notificationError = await insertNotificationWithFallback({
+        user_id: request.requester_id,
+        type: `adoption_${status}`,
+        message,
+        created_at: new Date().toISOString(),
+        link: `/post/${request.post_id}`,
+        post_id: request.post_id,
+        requester_id: request.owner_id,
+      });
 
       if (notificationError) {
         console.error("Error creating notification:", notificationError);

--- a/src/components/NotificationBadge.tsx
+++ b/src/components/NotificationBadge.tsx
@@ -19,7 +19,8 @@ interface Notification {
   user_id: string;
   type: string;
   message: string;
-  read: boolean;
+  read?: boolean;
+  is_read?: boolean;
   created_at: string;
   link?: string;
   post_id?: number;
@@ -36,6 +37,22 @@ interface EnhancedNotification extends Notification {
   petAge?: number;
   requesterName?: string;
 }
+
+const isNotificationRead = (notification: Notification) =>
+  notification.read ?? notification.is_read ?? false;
+
+const isMissingColumnError = (
+  error: { message?: string | null; details?: string | null } | null,
+  column: string
+) => {
+  if (!error) return false;
+  const errorText = `${error.message ?? ""} ${error.details ?? ""}`.toLowerCase();
+  return (
+    errorText.includes(`"${column.toLowerCase()}"`) ||
+    errorText.includes(`'${column.toLowerCase()}'`) ||
+    errorText.includes(` ${column.toLowerCase()} `)
+  );
+};
 
 export const NotificationBadge: React.FC = () => {
   const { user } = useAuth();
@@ -56,9 +73,52 @@ export const NotificationBadge: React.FC = () => {
   const [selectMode, setSelectMode] = useState(false);
   const navigate = useNavigate();
 
+  const markNotificationAsReadInDb = async (notificationId: number) => {
+    const primaryUpdate = await supabase
+      .from("notifications")
+      .update({ read: true })
+      .eq("id", notificationId);
+
+    if (!isMissingColumnError(primaryUpdate.error, "read")) {
+      return primaryUpdate.error;
+    }
+
+    const fallbackUpdate = await supabase
+      .from("notifications")
+      .update({ is_read: true })
+      .eq("id", notificationId);
+
+    return fallbackUpdate.error;
+  };
+
+  const markAllNotificationsAsReadInDb = async (userId: string) => {
+    const primaryUpdate = await supabase
+      .from("notifications")
+      .update({ read: true })
+      .eq("user_id", userId)
+      .eq("read", false);
+
+    if (!isMissingColumnError(primaryUpdate.error, "read")) {
+      return primaryUpdate.error;
+    }
+
+    const fallbackUpdate = await supabase
+      .from("notifications")
+      .update({ is_read: true })
+      .eq("user_id", userId)
+      .eq("is_read", false);
+
+    return fallbackUpdate.error;
+  };
+
   // Fetch unread notifications count
   useEffect(() => {
-    if (!user) return;
+    if (!user) {
+      setUnreadCount(0);
+      setNotifications([]);
+      setEnhancedNotifications([]);
+      return;
+    }
 
     const fetchNotifications = async () => {
       setLoading(true);
@@ -77,7 +137,7 @@ export const NotificationBadge: React.FC = () => {
         if (data) {
           setNotifications(data);
           // Count unread ones
-          const unread = data.filter((n) => !n.read).length;
+          const unread = data.filter((n) => !isNotificationRead(n)).length;
           setUnreadCount(unread);
 
           // Enhance notifications with additional data
@@ -157,11 +217,15 @@ export const NotificationBadge: React.FC = () => {
 
     // Set up real-time subscription for new notifications
     const subscription = supabase
-      .channel("notifications_changes")
+      .channel(
+        `notifications_changes_${user.id}_${Math.random()
+          .toString(36)
+          .slice(2)}`
+      )
       .on(
         "postgres_changes",
         {
-          event: "INSERT",
+          event: "*",
           schema: "public",
           table: "notifications",
           filter: `user_id=eq.${user.id}`,
@@ -173,7 +237,7 @@ export const NotificationBadge: React.FC = () => {
       .subscribe();
 
     return () => {
-      subscription.unsubscribe();
+      supabase.removeChannel(subscription);
     };
   }, [user]);
 
@@ -196,8 +260,69 @@ export const NotificationBadge: React.FC = () => {
       if (data) {
         setNotifications(data);
         // Count unread ones
-        const unread = data.filter((n) => !n.read).length;
+        const unread = data.filter((n) => !isNotificationRead(n)).length;
         setUnreadCount(unread);
+
+        const enhanced = await Promise.all(
+          data.map(async (notification) => {
+            const enhancedNotification: EnhancedNotification = {
+              ...notification,
+            };
+
+            if (
+              notification.type === "adoption_request" &&
+              notification.requester_id
+            ) {
+              try {
+                if (notification.post_id) {
+                  const { data: requestData } = await supabase
+                    .from("adoption_requests")
+                    .select("id, status, created_at")
+                    .eq("post_id", notification.post_id)
+                    .eq("requester_id", notification.requester_id)
+                    .order("created_at", { ascending: false })
+                    .maybeSingle();
+
+                  if (requestData) {
+                    enhancedNotification.requestId = requestData.id;
+                    enhancedNotification.requestStatus = requestData.status;
+                    enhancedNotification.requestDate = requestData.created_at;
+                  }
+                }
+
+                if (notification.post_id) {
+                  const { data: postData } = await supabase
+                    .from("posts")
+                    .select("name, image_url, breed, age")
+                    .eq("id", notification.post_id)
+                    .maybeSingle();
+
+                  if (postData) {
+                    enhancedNotification.petName = postData.name || "a pet";
+                    enhancedNotification.petImage = postData.image_url;
+                    enhancedNotification.petBreed = postData.breed;
+                    enhancedNotification.petAge = postData.age;
+                  }
+                }
+
+                if (notification.requester_id) {
+                  const requesterName = await getRequesterNameForNotification(
+                    notification.requester_id
+                  );
+                  if (requesterName) {
+                    enhancedNotification.requesterName = requesterName;
+                  }
+                }
+              } catch (err) {
+                console.error("Error enhancing notification:", err);
+              }
+            }
+
+            return enhancedNotification;
+          })
+        );
+
+        setEnhancedNotifications(enhanced);
 
         // Reset selection when refreshing
         setSelectedNotifications([]);
@@ -253,10 +378,7 @@ export const NotificationBadge: React.FC = () => {
   };
 
   const markAsRead = async (notificationId: number) => {
-    const { error } = await supabase
-      .from("notifications")
-      .update({ read: true })
-      .eq("id", notificationId);
+    const error = await markNotificationAsReadInDb(notificationId);
 
     if (error) {
       console.error("Error marking notification as read:", error);
@@ -267,7 +389,7 @@ export const NotificationBadge: React.FC = () => {
     setNotifications((prevNotifications) =>
       prevNotifications.map((notification) =>
         notification.id === notificationId
-          ? { ...notification, read: true }
+          ? { ...notification, read: true, is_read: true }
           : notification
       )
     );
@@ -275,7 +397,7 @@ export const NotificationBadge: React.FC = () => {
     setEnhancedNotifications((prevNotifications) =>
       prevNotifications.map((notification) =>
         notification.id === notificationId
-          ? { ...notification, read: true }
+          ? { ...notification, read: true, is_read: true }
           : notification
       )
     );
@@ -293,7 +415,7 @@ export const NotificationBadge: React.FC = () => {
     }
 
     // Mark as read
-    if (!notification.read) {
+    if (!isNotificationRead(notification)) {
       markAsRead(notification.id);
     }
 
@@ -368,13 +490,9 @@ export const NotificationBadge: React.FC = () => {
   };
 
   const markAllAsRead = async () => {
-    if (notifications.length === 0) return;
+    if (notifications.length === 0 || !user) return;
 
-    const { error } = await supabase
-      .from("notifications")
-      .update({ read: true })
-      .eq("user_id", user?.id)
-      .eq("read", false);
+    const error = await markAllNotificationsAsReadInDb(user.id);
 
     if (error) {
       console.error("Error marking all notifications as read:", error);
@@ -382,11 +500,19 @@ export const NotificationBadge: React.FC = () => {
     }
 
     setNotifications((prevNotifications) =>
-      prevNotifications.map((notification) => ({ ...notification, read: true }))
+      prevNotifications.map((notification) => ({
+        ...notification,
+        read: true,
+        is_read: true,
+      }))
     );
 
     setEnhancedNotifications((prevNotifications) =>
-      prevNotifications.map((notification) => ({ ...notification, read: true }))
+      prevNotifications.map((notification) => ({
+        ...notification,
+        read: true,
+        is_read: true,
+      }))
     );
 
     setUnreadCount(0);
@@ -500,7 +626,13 @@ export const NotificationBadge: React.FC = () => {
     <div className="relative">
       <button
         className="relative p-2 rounded-full hover:bg-violet-100 transition-colors"
-        onClick={() => setShowDropdown(!showDropdown)}
+        onClick={() => {
+          const willOpen = !showDropdown;
+          setShowDropdown(willOpen);
+          if (willOpen) {
+            refreshNotifications();
+          }
+        }}
       >
         <FaBell className="text-violet-800 text-xl" />
         {unreadCount > 0 && (
@@ -586,8 +718,8 @@ export const NotificationBadge: React.FC = () => {
                   key={notification.id}
                   className={`p-3 border-b border-gray-100 ${
                     selectMode ? "cursor-pointer" : ""
-                  } hover:bg-violet-50 transition-colors ${
-                    !notification.read ? "bg-violet-50" : ""
+                   } hover:bg-violet-50 transition-colors ${
+                    !isNotificationRead(notification) ? "bg-violet-50" : ""
                   } ${
                     selectedNotifications.includes(notification.id)
                       ? "bg-violet-100"

--- a/src/components/PostDetail.tsx
+++ b/src/components/PostDetail.tsx
@@ -18,6 +18,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { toast } from "react-hot-toast";
 import { AdoptionRequestsList } from "./AdoptionRequestsList";
 import { MessageButton } from "./MessageButton";
+import { resolveUserIdentity } from "../utils/userIdentity";
 
 interface ModalProps {
   isOpen: boolean;
@@ -281,18 +282,50 @@ const updatePost = async (postId: number, updates: Partial<Post>) => {
   if (error) throw error;
 };
 
+const isPostIdSchemaError = (error: { code?: string | null; message?: string | null; details?: string | null }) => {
+  if (!error) return false;
+  const text = `${error.message || ""} ${error.details || ""}`.toLowerCase();
+  return error.code === "23503" || (text.includes("post_id") && text.includes("foreign key"));
+};
+
+const insertNotificationWithFallback = async (payload: {
+  user_id: string;
+  type: string;
+  message: string;
+  created_at: string;
+  requester_id?: string;
+  link?: string;
+  post_id?: number;
+}) => {
+  const firstAttempt = await supabase.from("notifications").insert([payload]);
+  if (!firstAttempt.error) return null;
+
+  if (payload.post_id && isPostIdSchemaError(firstAttempt.error)) {
+    const withoutPostId = { ...payload };
+    delete withoutPostId.post_id;
+    const secondAttempt = await supabase
+      .from("notifications")
+      .insert([withoutPostId]);
+    return secondAttempt.error;
+  }
+
+  return firstAttempt.error;
+};
+
 // Utility function to create adoption chat (shared between PostDetail and AdoptionRequestDetails)
 const createAdoptionChat = async ({
   adopterId,
   ownerId,
   postId,
   adopterName,
+  ownerName,
   petName,
 }: {
   adopterId: string;
   ownerId: string;
   postId: number;
   adopterName: string;
+  ownerName?: string;
   petName?: string;
 }) => {
   // Check for existing conversation
@@ -303,32 +336,54 @@ const createAdoptionChat = async ({
       specific_post_id: postId,
     });
   if (!existingError && existing && existing.length > 0) return existing[0].conversation_id;
-  
-  // Create new conversation
-  const { data, error } = await supabase
+
+  const baseConversationPayload = {
+    title: adopterName || ownerName || "Chat",
+    adopter_name: adopterName,
+    owner_name: ownerName || "",
+    pet_name: petName,
+    is_group: false,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+
+  let createResult = await supabase
     .from("conversations")
-    .insert([
-      {
-        title: adopterName,
-        post_id: postId,
-        adopter_name: adopterName,
-        owner_name: "",
-        pet_name: petName,
-        is_group: false,
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      },
-    ])
+    .insert([{ ...baseConversationPayload, post_id: postId }])
     .select()
     .single();
-  if (error) throw error;
-  const conversationId = data.id;
-  
-  // Add both users to conversation
-  await supabase.from("user_conversations").insert([
-    { user_id: adopterId, conversation_id: conversationId, joined_at: new Date().toISOString() },
-    { user_id: ownerId, conversation_id: conversationId, joined_at: new Date().toISOString() },
-  ]);
+
+  if (createResult.error && isPostIdSchemaError(createResult.error)) {
+    createResult = await supabase
+      .from("conversations")
+      .insert([baseConversationPayload])
+      .select()
+      .single();
+  }
+
+  if (createResult.error) throw createResult.error;
+
+  const conversationId = createResult.data.id;
+
+  const { error: membersError } = await supabase
+    .from("user_conversations")
+    .upsert(
+      [
+        {
+          user_id: adopterId,
+          conversation_id: conversationId,
+          joined_at: new Date().toISOString(),
+        },
+        {
+          user_id: ownerId,
+          conversation_id: conversationId,
+          joined_at: new Date().toISOString(),
+        },
+      ],
+      { onConflict: "user_id,conversation_id", ignoreDuplicates: true }
+    );
+
+  if (membersError) throw membersError;
   return conversationId;
 };
 
@@ -377,48 +432,37 @@ const sendAdoptionRequest = async (
     }
 
     // Also create a notification for the pet owner
-    const { error: notificationError } = await supabase
-      .from("notifications")
-      .insert([
-        {
-          user_id: ownerId,
-          type: "adoption_request",
-          message: `New adoption request for ${petName}${reason ? ` - Reason: ${reason}` : ""}`,
-          created_at: new Date().toISOString(),
-          read: false,
-          link: `/post/${postId}`,
-          post_id: postId,
-        },
-      ]);
+    const { name: requesterName } = await resolveUserIdentity(requesterId);
+    const { name: ownerName } = await resolveUserIdentity(ownerId);
+
+    const notificationError = await insertNotificationWithFallback({
+      user_id: ownerId,
+      type: "adoption_request",
+      message: `New adoption request for ${petName}${reason ? ` - Reason: ${reason}` : ""}`,
+      created_at: new Date().toISOString(),
+      requester_id: requesterId,
+      link: `/post/${postId}`,
+      post_id: postId,
+    });
 
     if (notificationError) {
       console.error("Error creating notification:", notificationError);
-      // Don't throw here, we still want to consider the adoption request as successful
-      // Just log the error for debugging
     }
 
     // Create chat immediately after submitting adoption request
     try {
-      // Get requester name for chat
-      const { data: requesterProfile } = await supabase
-        .from("profiles")
-        .select("full_name")
-        .eq("id", requesterId)
-        .single();
-      
-      const requesterName = requesterProfile?.full_name || "User";
       const conversationId = await createAdoptionChat({
         adopterId: requesterId,
-        ownerId: ownerId,
-        postId: postId,
+        ownerId,
+        postId,
         adopterName: requesterName,
-        petName: petName,
+        ownerName,
+        petName,
       });
-      
+
       return { ...data, conversationId };
     } catch (chatError) {
       console.error("Error creating chat:", chatError);
-      // Don't throw - adoption request was successful, chat creation is optional
     }
 
     return data;
@@ -460,18 +504,15 @@ const cancelAdoptionRequest = async (postId: number, requesterId: string) => {
     }
 
     // Create a notification for the owner
-    const { error: notificationError } = await supabase
-      .from("notifications")
-      .insert([
-        {
-          user_id: existingRequests[0].owner_id,
-          type: "adoption_cancelled",
-          message: `An adoption request for your pet has been cancelled`,
-          created_at: new Date().toISOString(),
-          read: false,
-          link: `/post/${postId}`,
-        },
-      ]);
+    const notificationError = await insertNotificationWithFallback({
+      user_id: existingRequests[0].owner_id,
+      type: "adoption_cancelled",
+      message: `An adoption request for your pet has been cancelled`,
+      created_at: new Date().toISOString(),
+      requester_id: requesterId,
+      link: `/post/${postId}`,
+      post_id: postId,
+    });
 
     if (notificationError) {
       console.error(

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -5,7 +5,6 @@ import { supabase } from "../supabase-client";
 interface AuthResponse {
   success: boolean;
   error?: string;
-  declinedReason?: string | null;
 }
 
 interface AdoptionValidation {
@@ -110,11 +109,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         }
       }
       
-      // Check if user already exists - get existing role to preserve it
+      // Check if user already exists
       const { data: existingUser, error: checkError } = await supabase
         .from("users")
-        .select("user_id, role, adoption_validation")
-        .eq("user_id", user.id)
+        .select("id, adoption_validation")
+        .eq("id", user.id)
         .maybeSingle();
       
       if (checkError) {
@@ -125,32 +124,23 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       // Only use existing adoption_validation if there's no cached one (to avoid overwriting with null)
       const finalAdoptionValidation = adoptionValidation || existingUser?.adoption_validation || null;
       
-      // Preserve existing role from database - don't overwrite admin/vet roles
-      // Only use metadata role if user doesn't exist yet (new signup)
-      const finalRole = existingUser?.role || user.user_metadata?.role || "user";
-      
       console.log("Final adoption validation for upsert:", finalAdoptionValidation);
-      console.log("Preserving role:", finalRole, "(existing:", existingUser?.role, ", metadata:", user.user_metadata?.role, ")");
       
       const userData = {
-        user_id: user.id,
+        id: user.id,
         email: user.email || "",
         full_name: user.user_metadata?.full_name || user.email?.split("@")[0] || "Unknown",
-        role: finalRole,
+        role: user.user_metadata?.role || "user",
         adoption_validation: finalAdoptionValidation,
         created_at: new Date().toISOString(),
       };
       
       console.log("Upserting user data:", userData);
       
-      // Upsert user profile - use update only for role to preserve existing role
+      // Upsert user profile regardless of admin/vet verification status
       const { data: upsertData, error: upsertError } = await supabase
         .from("users")
-        .upsert([userData], { 
-          onConflict: 'user_id',
-          // Only update role if it's not already set (preserve existing admin/vet roles)
-          ignoreDuplicates: false
-        })
+        .upsert([userData], { onConflict: 'id' })
         .select();
       
       if (upsertError) {
@@ -163,6 +153,25 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           .select();
         if (insertError) {
           console.error('Insert fallback also failed:', insertError);
+          // As a last-resort, call server RPC to create profile (SECURITY DEFINER RPC should be installed)
+          try {
+            if (adoptionValidation && typeof adoptionValidation === 'object') {
+              await supabase.rpc('create_user_profile_if_missing', {
+                _validation: adoptionValidation,
+                _full_name: userData.full_name,
+                _role: userData.role,
+              });
+                // Also persist the structured adoption answers into rows if table exists
+                try {
+                  await supabase.rpc('save_adoption_validation_for_current_user', { _validation: adoptionValidation });
+                } catch (innerRpcErr) {
+                  console.warn('save_adoption_validation_for_current_user failed:', innerRpcErr);
+                }
+              if (cached) localStorage.removeItem('pendingAdoptionValidation');
+            }
+          } catch (rpcErr) {
+            console.warn('RPC create_user_profile_if_missing failed:', rpcErr);
+          }
         } else {
           console.log('Insert fallback succeeded:', insertData);
           // Clear cached adoption validation after successful insert
@@ -175,6 +184,24 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         // Clear cached adoption validation after successful upsert
         if (cached) {
           localStorage.removeItem("pendingAdoptionValidation");
+        }
+        // Also attempt RPC to ensure profiles row exists (no-op if already present)
+        try {
+          await supabase.rpc('create_user_profile_if_missing', {
+            _validation: finalAdoptionValidation,
+            _full_name: userData.full_name,
+            _role: userData.role,
+          });
+          // Persist adoption validation into rows if available
+          if (finalAdoptionValidation) {
+            try {
+              await supabase.rpc('save_adoption_validation_for_current_user', { _validation: finalAdoptionValidation });
+            } catch (inner) {
+              console.warn('save_adoption_validation_for_current_user failed after upsert:', inner);
+            }
+          }
+        } catch (rpcErr) {
+          console.warn('RPC create_user_profile_if_missing after upsert failed:', rpcErr);
         }
       }
     };
@@ -202,14 +229,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     adoptionValidation?: AdoptionValidation
   ): Promise<AuthResponse> => {
     try {
-      const cleanedEmail = email.toLowerCase().trim();
-      // CLEAN OUT DECLINED USER RECORD
-      await supabase
-        .from("users")
-        .delete()
-        .eq("email", cleanedEmail)
-        .eq("declined", true);
-
       const fullName = first_name && last_name 
         ? `${first_name} ${last_name}` 
         : email.split("@")[0];
@@ -257,20 +276,23 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         error: authError?.message 
       });
 
-      // If signup fails due to existing email
+      // If signup fails due to existing email or server error
       if (authError) {
-        console.error("Signup error:", authError);
+        // Log full error object for diagnostics
+        console.error("Signup error (full):", authError);
+        const msg = authError?.message || JSON.stringify(authError);
         if (
-          authError.message.includes("already registered") ||
-          authError.message.includes("already exists") ||
-          authError.message.includes("User already registered")
+          msg.includes("already registered") ||
+          msg.includes("already exists") ||
+          msg.includes("User already registered")
         ) {
           return {
             success: false,
             error: "This email is already registered. Please use the login page to sign in.",
           };
         }
-        return { success: false, error: authError.message };
+        // Return the full error object stringified so UI can show more detail
+        return { success: false, error: typeof authError === 'string' ? authError : JSON.stringify(authError) };
       }
 
       // If user was created, try to insert into users table immediately
@@ -295,7 +317,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           .from("users")
           .insert([
             {
-              user_id: signUpData.user.id,
+              id: signUpData.user.id,
               email: email.toLowerCase().trim(),
               full_name: fullName,
               role,
@@ -305,11 +327,32 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
           ])
           .select();
         
-        if (insertError) {
+          if (insertError) {
           console.error("Failed to insert user profile on sign up (this is OK, will retry after verification):", insertError);
           console.error("Insert error details:", JSON.stringify(insertError, null, 2));
           // Keep adoption validation in localStorage for retry after email verification
-        } else {
+          // Try RPC immediately so server creates the user/profile using auth.uid()
+          try {
+            // Call RPC regardless of whether adoption answers exist so a profiles row is created.
+            await supabase.rpc('create_user_profile_if_missing', {
+              _validation: finalAdoptionValidation,
+              _full_name: fullName,
+              _role: role,
+            });
+            // Persist adoption validation into rows if available (no-op if null)
+            try {
+              await supabase.rpc('save_adoption_validation_for_current_user', { _validation: finalAdoptionValidation });
+            } catch (saveErr) {
+              console.warn('save_adoption_validation_for_current_user failed after signup insert error:', saveErr);
+            }
+            // If RPC succeeded, clear localStorage
+            localStorage.removeItem('pendingAdoptionValidation');
+          } catch (rpcErr: any) {
+            console.warn('RPC create_user_profile_if_missing failed after signup insert error:', rpcErr);
+            // Return a clear error so the UI can show meaningful feedback.
+            return { success: false, error: rpcErr?.message || 'Database error saving new user' };
+          }
+          } else {
           console.log("Successfully inserted user profile:", insertData);
           // Clear localStorage since we successfully saved it
           if (finalAdoptionValidation) {
@@ -372,28 +415,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   ): Promise<AuthResponse> => {
     try {
       console.log("Attempting to sign in...");
-      const cleanedEmail = email.toLowerCase().trim();
-      
-      // FIRST: Check if user is declined BEFORE attempting password authentication
-      // This way we can show the decline modal even if password is wrong
-      const { data: declinedCheck, error: declinedCheckError } = await supabase
-        .from("users")
-        .select("declined, declined_reason, user_id")
-        .eq("email", cleanedEmail)
-        .maybeSingle();
-
-      // If we found a declined user, return decline reason immediately
-      if (!declinedCheckError && declinedCheck && declinedCheck.declined === true) {
-        return {
-          success: false,
-          error: "Your account has been declined and you cannot log in.",
-          declinedReason: declinedCheck.declined_reason || null,
-        };
-      }
-
-      // Now attempt password authentication
       const { data, error } = await supabase.auth.signInWithPassword({
-        email: cleanedEmail,
+        email: email.toLowerCase(),
         password,
       });
 
@@ -421,10 +444,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         };
       }
 
-      // Get user role, verification, and declined status from users table
+      // Get user role and verification from users table
       const { data: userData, error: userError } = await supabase
         .from("users")
-        .select("role, verified, declined, declined_reason")
+        .select("role, verified")
         .eq("user_id", data.user.id)
         .single();
 
@@ -434,16 +457,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         return {
           success: false,
           error: "Error fetching user account. Please contact support.",
-        };
-      }
-
-      // Double-check declined status (in case it was set after the initial check)
-      if (userData.declined === true) {
-        await supabase.auth.signOut();
-        return {
-          success: false,
-          error: "Your account has been declined and you cannot log in.",
-          declinedReason: userData.declined_reason || null,
         };
       }
 
@@ -472,26 +485,37 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         } catch {}
         localStorage.removeItem("pendingAdoptionValidation"); // Clean up after inserting
       }
-      // Preserve existing role - don't overwrite admin/vet roles
-      // Only update if the role from database is valid, otherwise keep existing
       const { error: upsertError } = await supabase
         .from("users")
         .upsert([
           {
-            user_id: data.user.id,
+            id: data.user.id,
             email: data.user.email,
-            role: userData?.role || "user", // userData comes from database query, so it's already the correct role
+            role: userData?.role || "user",
             full_name: data.user.user_metadata?.full_name || data.user.email?.split("@")[0] || "Unknown",
             adoption_validation: adoptionValidation,
             created_at: new Date().toISOString(),
           }
-        ], { 
-          onConflict: 'user_id',
-          // Don't update role if it already exists (preserve admin/vet roles)
-          // The role from userData is already correct from the database query above
-        });
+        ], { onConflict: 'id' });
       if (upsertError) {
         console.error('Upsert error:', upsertError);
+        // Fallback to server RPC to ensure adoption validation is stored
+        try {
+          if (adoptionValidation) {
+            await supabase.rpc('create_user_profile_if_missing', {
+              _validation: adoptionValidation,
+              _full_name: data.user.user_metadata?.full_name || data.user.email?.split('@')[0] || 'Unknown',
+              _role: userData?.role || 'user',
+            });
+            try {
+              await supabase.rpc('save_adoption_validation_for_current_user', { _validation: adoptionValidation });
+            } catch (saveErr) {
+              console.warn('save_adoption_validation_for_current_user failed on sign in upsert fallback:', saveErr);
+            }
+          }
+        } catch (rpcErr) {
+          console.warn('RPC create_user_profile_if_missing on sign in upsert failure:', rpcErr);
+        }
       }
 
       console.log("Sign in successful");

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -4,6 +4,7 @@ import { FaBars, FaComments, FaPaperPlane, FaChevronLeft, FaChevronRight, FaChec
 import { supabase } from "../supabase-client";
 import { useAuth } from "../context/AuthContext";
 import toast from "react-hot-toast";
+import { resolveUserIdentity } from "../utils/userIdentity";
 
 // Interface for chat messages
 interface Message {
@@ -48,6 +49,12 @@ interface ConversationDetails {
   updated_at: string;
 }
 
+const isPlaceholderName = (value?: string | null) =>
+  !value ||
+  value.trim().length === 0 ||
+  /^user(\s|$)/i.test(value) ||
+  /unknown/i.test(value);
+
 const ChatPage: React.FC = () => {
   // Get the conversation ID from URL params, or null if on main chat page
   const { conversationId } = useParams<{ conversationId?: string }>();
@@ -88,75 +95,9 @@ const ChatPage: React.FC = () => {
   // Function to get user information - prioritize user name over pet name
   const getUserInfo = useCallback(
     async (userId: string) => {
-      if (!userId) return { name: "Unknown", email: "", avatar: null };
-
-      try {
-        console.log(`Getting user info for user ID: ${userId}`);
-
-        // First, try to get user's actual name from profiles table
-        const { data: profileData, error: profileError } = await supabase
-          .from("profiles")
-          .select("full_name, email, avatar_url")
-          .eq("id", userId)
-          .single();
-
-        if (!profileError && profileData && profileData.full_name) {
-          console.log(`Found user name from profiles: ${profileData.full_name}`);
-            return {
-            name: profileData.full_name,
-            email: profileData.email || "",
-            avatar: profileData.avatar_url || null,
-          };
-        }
-
-        // Try users table as fallback
-        const { data: userData, error: userError } = await supabase
-          .from("users")
-          .select("full_name, email")
-          .eq("user_id", userId)
-          .single();
-
-        if (!userError && userData && userData.full_name) {
-          console.log(`Found user name from users table: ${userData.full_name}`);
-          return {
-            name: userData.full_name,
-            email: userData.email || "",
-            avatar: null,
-          };
-        }
-
-        // Fallback to email via RPC function
-        const { data: emailData, error: emailError } = await supabase.rpc(
-          "get_user_email",
-          { user_id: userId }
-        );
-
-        if (!emailError && emailData && emailData[0]?.email) {
-          // Extract name from email if no full name available
-          const emailName = emailData[0].email.split("@")[0];
-          return {
-            name: emailName,
-            email: emailData[0].email,
-            avatar: null,
-          };
-        }
-
-        // Final fallback - use user ID
-        return {
-          name: `User ${userId.substring(0, 6)}`,
-          email: "",
-          avatar: null,
-        };
-      } catch (error) {
-        console.error("Error getting user info:", error);
-        return {
-          name: `User ${userId.substring(0, 6)}`,
-          email: "",
-          avatar: null,
-        };
-      }
+      return resolveUserIdentity(userId);
     },
-    [user]
+    []
   );
 
   // Fetch all conversations for the current user
@@ -234,13 +175,13 @@ const ChatPage: React.FC = () => {
 
                 let otherUserId = null;
                 let otherUserInfo = {
-                  name: "Unknown",
+                  name: "User",
                   email: "",
                   avatar: null,
                 };
 
-                // Set adopter_name and owner_name if they aren't already set
-                if (convo.adopter_name === null && convo.owner_name === null) {
+                // Refresh participant names if missing or placeholder values
+                if (isPlaceholderName(convo.adopter_name) || isPlaceholderName(convo.owner_name)) {
                   if (members && members.length > 0) {
                     otherUserId = members[0].user_id;
                     
@@ -255,55 +196,26 @@ const ChatPage: React.FC = () => {
 
                     if (!adoptionError && adoptionData && adoptionData.length > 0) {
                       const adoption = adoptionData[0];
-                      
-                      // Get both users' emails
-                      const [currentUserEmailResult, otherUserEmailResult] = await Promise.all([
-                        supabase.rpc("get_user_email", { user_id: user.id }),
-                        supabase.rpc("get_user_email", { user_id: otherUserId })
+
+                      const [currentIdentity, otherIdentity] = await Promise.all([
+                        getUserInfo(user.id),
+                        getUserInfo(otherUserId),
                       ]);
 
-                      console.log("Current user email result:", currentUserEmailResult);
-                      console.log("Other user email result:", otherUserEmailResult);
-                      
-                      let currentUserEmail = currentUserEmailResult.data?.[0]?.email || "You";
-                      let otherUserEmail = otherUserEmailResult.data?.[0]?.email || "Other User";
-                      
-                      // If the RPC function didn't work, try direct approach
-                      if (currentUserEmail === "You" && user.email) {
-                        currentUserEmail = user.email;
-                      }
-                      
-                      if (otherUserEmail === "Other User") {
-                        // Try to get the other user's info from profiles table
-                        try {
-                          const { data: profileData, error: profileError } = await supabase
-                            .from('profiles')
-                            .select('full_name')
-                            .eq('id', otherUserId)
-                            .single();
-                          
-                          if (!profileError && profileData?.full_name) {
-                            otherUserEmail = profileData.full_name;
-                            console.log("Got other user name via profiles table:", otherUserEmail);
-                          }
-                        } catch (profileQueryError) {
-                          console.log("Profile query failed, using fallback");
-                        }
-                      }
-                      
-                      console.log("Final current user email:", currentUserEmail);
-                      console.log("Final other user email:", otherUserEmail);
+                      const currentUserName =
+                        currentIdentity.name || user.email || "You";
+                      const otherUserName = otherIdentity.name || "User";
 
                       // Determine who is adopter and who is owner
                       let adopterName, ownerName;
                       if (user.id === adoption.requester_id) {
                         // Current user is the adopter
-                        adopterName = currentUserEmail;
-                        ownerName = otherUserEmail;
+                        adopterName = currentUserName;
+                        ownerName = otherUserName;
                       } else {
                         // Current user is the owner
-                        adopterName = otherUserEmail;
-                        ownerName = currentUserEmail;
+                        adopterName = otherUserName;
+                        ownerName = currentUserName;
                       }
 
                       // Update conversation with participant names
@@ -320,47 +232,25 @@ const ChatPage: React.FC = () => {
                       convo.owner_name = ownerName;
                     } else {
                       // Fallback to simple approach if no adoption request found
-                      const yourName = user.email || "You";
-                    const { data: otherUserEmailResult } = await supabase.rpc(
-                      "get_user_email",
-                      { user_id: otherUserId }
-                    );
-
-                      console.log("Fallback other user email result:", otherUserEmailResult);
-                      let otherUserEmail = otherUserEmailResult?.data?.[0]?.email || "Other User";
-                      
-                      // If the RPC function didn't work, try profiles table
-                      if (otherUserEmail === "Other User") {
-                        try {
-                          const { data: profileData, error: profileError } = await supabase
-                            .from('profiles')
-                            .select('full_name')
-                            .eq('id', otherUserId)
-                            .single();
-                          
-                          if (!profileError && profileData?.full_name) {
-                            otherUserEmail = profileData.full_name;
-                            console.log("Got other user name via profiles table (fallback):", otherUserEmail);
-                          }
-                        } catch (profileQueryError) {
-                          console.log("Profile query failed in fallback, using default");
-                        }
-                      }
-                      
-                      console.log("Fallback other user email:", otherUserEmail);
+                      const [yourIdentity, otherIdentity] = await Promise.all([
+                        getUserInfo(user.id),
+                        getUserInfo(otherUserId),
+                      ]);
+                      const yourName = yourIdentity.name || user.email || "You";
+                      const otherUserName = otherIdentity.name || "User";
 
                     // Update conversation with participant names
                     await supabase
                       .from("conversations")
                       .update({
                         adopter_name: yourName,
-                        owner_name: otherUserEmail,
+                        owner_name: otherUserName,
                       })
                       .eq("id", convo.id);
 
                     // Set values for current session
                     convo.adopter_name = yourName;
-                    convo.owner_name = otherUserEmail;
+                    convo.owner_name = otherUserName;
                     }
                   }
                 }
@@ -500,26 +390,15 @@ const ChatPage: React.FC = () => {
                   );
                 }
 
-                // Determine the base display name for the other user (owner/adopter)
-                let baseDisplayName = otherUserInfo.name || "User";
-                
-                // If we have adopter_name and owner_name, show the appropriate one
-                if (convo.adopter_name && convo.owner_name) {
-                  // Show the other person's name (not the current user's name)
-                  if (user.email === convo.adopter_name) {
-                    // Current user is adopter, show owner name
-                    baseDisplayName = convo.owner_name;
-                  } else if (user.email === convo.owner_name) {
-                    // Current user is owner, show adopter name
-                    baseDisplayName = convo.adopter_name;
-                  } else {
-                    // Fallback to other user info
-                    baseDisplayName = otherUserInfo.name || "User";
-                  }
-                }
-
-                // Use user name for display - don't combine with pet name
-                const combinedDisplayName = baseDisplayName;
+                // Always prefer the actual other user's resolved profile name.
+                const resolvedOtherUserName = otherUserInfo.name;
+                const combinedDisplayName = !isPlaceholderName(
+                  resolvedOtherUserName
+                )
+                  ? resolvedOtherUserName
+                  : !isPlaceholderName(convo.title)
+                  ? convo.title
+                  : "User";
 
                 const processedConvo = {
                   conversation_id: convo.id,
@@ -565,7 +444,9 @@ const ChatPage: React.FC = () => {
                   created_at: convo.created_at,
                   updated_at: convo.updated_at,
                   last_message: "Error loading message",
-                  other_user_name: "User",
+                  other_user_name: !isPlaceholderName(convo.title)
+                    ? convo.title
+                    : "User",
                   unread_count: 0,
                 } as Conversation;
               }
@@ -762,42 +643,8 @@ const ChatPage: React.FC = () => {
 
       if (!membersError && members && members.length > 0) {
         otherUserId = members[0].user_id;
-
-        // Check adoption requests to determine roles
-        const { data: adoptionData, error: adoptionError } = await supabase
-          .from("adoption_requests")
-          .select("requester_id, owner_id, pet_name")
-          .or(`requester_id.eq.${user.id},owner_id.eq.${user.id}`)
-          .or(`requester_id.eq.${otherUserId},owner_id.eq.${otherUserId}`)
-          .order("updated_at", { ascending: false })
-          .limit(1);
-
-        if (!adoptionError && adoptionData && adoptionData.length > 0) {
-          // Get the other user's email/name
-          const { data: otherUserEmailResult } = await supabase.rpc(
-            "get_user_email",
-            { user_id: otherUserId }
-          );
-          otherUserName = otherUserEmailResult?.data?.[0]?.email || "Other User";
-          
-          // If the RPC function didn't work, try profiles table
-          if (otherUserName === "Other User") {
-            try {
-              const { data: profileData, error: profileError } = await supabase
-                .from('profiles')
-                .select('full_name')
-                .eq('id', otherUserId)
-                .single();
-              
-              if (!profileError && profileData?.full_name) {
-                otherUserName = profileData.full_name;
-                console.log("Got other user name via profiles table (fetchMessages):", otherUserName);
-              }
-            } catch (profileQueryError) {
-              console.log("Profile query failed in fetchMessages, using default");
-            }
-          }
-        }
+        const otherIdentity = await getUserInfo(otherUserId);
+        otherUserName = otherIdentity.name;
       }
 
       // Prepare a combined label for the other participant: \"Other Person · Pet\"
@@ -979,55 +826,31 @@ const ChatPage: React.FC = () => {
           adoptionData[0].pet_name
         ) {
           const adoption = adoptionData[0];
-          
-          // Get both users' emails to set proper names
-          const [currentUserEmailResult, otherUserEmailResult] = await Promise.all([
-            supabase.rpc("get_user_email", { user_id: user.id }),
-            supabase.rpc("get_user_email", { user_id: otherUserId })
-          ]);
 
-          let currentUserEmail = currentUserEmailResult.data?.[0]?.email || "You";
-          let otherUserEmail = otherUserEmailResult.data?.[0]?.email || "Other User";
-          
-          // If the RPC function didn't work, try direct approach
-          if (currentUserEmail === "You" && user.email) {
-            currentUserEmail = user.email;
-          }
-          
-          if (otherUserEmail === "Other User") {
-            try {
-              const { data: profileData, error: profileError } = await supabase
-                .from('profiles')
-                .select('full_name')
-                .eq('id', otherUserId)
-                .single();
-              
-              if (!profileError && profileData?.full_name) {
-                otherUserEmail = profileData.full_name;
-                console.log("Got other user name via profiles table (fetchConversationDetails):", otherUserEmail);
-              }
-            } catch (profileQueryError) {
-              console.log("Profile query failed in fetchConversationDetails, using default");
-            }
-          }
+          const [currentIdentity, otherIdentity] = await Promise.all([
+            getUserInfo(user.id),
+            getUserInfo(otherUserId),
+          ]);
+          const currentUserName = currentIdentity.name || user.email || "You";
+          const otherUserName = otherIdentity.name || "User";
 
           // Determine who is adopter and who is owner
           let adopterName, ownerName;
           if (user.id === adoption.requester_id) {
             // Current user is the adopter
-            adopterName = currentUserEmail;
-            ownerName = otherUserEmail;
+            adopterName = currentUserName;
+            ownerName = otherUserName;
           } else {
             // Current user is the owner
-            adopterName = otherUserEmail;
-            ownerName = currentUserEmail;
+            adopterName = otherUserName;
+            ownerName = currentUserName;
           }
 
           // This is handled in the update above
 
           // Get user names for the title
           const otherUserInfo = await getUserInfo(otherUserId);
-          const userDisplayName = otherUserInfo.name || otherUserEmail;
+          const userDisplayName = otherUserInfo.name || otherUserName;
 
           // Store this info in the conversation for future use
           await supabase
@@ -1230,7 +1053,7 @@ const ChatPage: React.FC = () => {
         setIsCreatingConversation(false);
       }
     },
-    [user, location.state, navigate]
+    [user, location.state, navigate, getUserInfo]
   );
 
   // Function to clean up duplicate conversations for the current user
@@ -1383,7 +1206,10 @@ const ChatPage: React.FC = () => {
           // Profile doesn't exist, create one
           await supabase.from("profiles").insert({
             id: user.id,
-            full_name: user.email || `User ${user.id.substring(0, 6)}`,
+            full_name:
+              user.user_metadata?.full_name ||
+              user.email?.split("@")[0] ||
+              `User ${user.id.substring(0, 6)}`,
             updated_at: new Date().toISOString(),
           });
         }
@@ -1494,35 +1320,15 @@ const ChatPage: React.FC = () => {
                 (c) => c.conversation_id === conversationId
               );
 
-              if (
-                currentConversation &&
-                currentConversation.adopter_name &&
-                currentConversation.owner_name
-              ) {
-                // Determine which base name to show based on the viewer's role
-                let baseName: string;
-                if (user.email === currentConversation.adopter_name) {
-                  // Viewer is adopter -> show owner name
-                  baseName = currentConversation.owner_name;
-                } else if (user.email === currentConversation.owner_name) {
-                  // Viewer is owner -> show adopter name
-                  baseName = currentConversation.adopter_name;
-                } else {
-                  // Fallback to getUserInfo if we can't match roles
               const senderInfo = await getUserInfo(newMessage.sender_id);
-                  baseName = senderInfo.name;
-                }
-
-                const petNameForLabel = currentConversation.pet_name;
-                formattedMessage.sender_name =
-                  petNameForLabel && baseName
-                    ? `${baseName} · ${petNameForLabel}`
-                    : baseName;
-              } else {
-                // Fallback to getUserInfo if conversation data not available
-                const senderInfo = await getUserInfo(newMessage.sender_id);
-                formattedMessage.sender_name = senderInfo.name;
-              }
+              const baseName = !isPlaceholderName(senderInfo.name)
+                ? senderInfo.name
+                : "User";
+              const petNameForLabel = currentConversation?.pet_name;
+              formattedMessage.sender_name =
+                petNameForLabel && baseName
+                  ? `${baseName} · ${petNameForLabel}`
+                  : baseName;
 
               formattedMessage.sender_avatar = null;
             }

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { FaPaw, FaLock, FaEnvelope, FaUser, FaEye, FaEyeSlash } from "react-icons/fa";
 import { useAuth } from "../context/AuthContext";
-import { TermsOfServiceModal } from "../components/TermsOfServiceModal";
 
 interface AdoptionValidation {
   hasExperience: string;
@@ -25,8 +24,6 @@ const SignUpPage = () => {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
-  const [acceptedTerms, setAcceptedTerms] = useState(false);
-  const [showTermsModal, setShowTermsModal] = useState(false);
   const [adoptionAnswers, setAdoptionAnswers] = useState<AdoptionValidation>({
     hasExperience: "",
     stableLiving: "",
@@ -117,10 +114,6 @@ const SignUpPage = () => {
       );
       return false;
     }
-    if (!acceptedTerms) {
-      setError("You must accept the Terms of Service to continue");
-      return false;
-    }
     return true;
   };
 
@@ -160,12 +153,6 @@ const SignUpPage = () => {
       return;
     }
 
-    // Final check: ensure terms are still accepted
-    if (!acceptedTerms) {
-      setError("You must accept the Terms of Service to create an account");
-      return;
-    }
-
     setLoading(true);
     setError("");
 
@@ -196,7 +183,18 @@ const SignUpPage = () => {
           navigate("/login");
         }, 3000);
       } else {
-        setError(error || "Sign up failed. Try again.");
+        // Show the full error message and object for debugging
+        let displayError = "Sign up failed. Try again.";
+        if (error) {
+          if (typeof error === 'string') displayError = error;
+          else if ((error as any)?.message) displayError = (error as any).message;
+          else displayError = JSON.stringify(error);
+        }
+        setError(displayError);
+        if (error) {
+          // Log the full error object for developer visibility
+          console.error("Signup failed with error (full object):", error);
+        }
       }
     } catch (error: unknown) {
       if (error instanceof Error) {
@@ -373,32 +371,6 @@ const SignUpPage = () => {
                      </div>
                    </div>
                  </div>
-
-                 <div className="flex items-start">
-                   <input
-                     type="checkbox"
-                     id="termsCheckbox"
-                     checked={acceptedTerms}
-                     onChange={(e) => {
-                       setAcceptedTerms(e.target.checked);
-                       setError("");
-                     }}
-                     className="mt-1 mr-3 h-4 w-4 text-violet-600 focus:ring-violet-500 border-gray-300 rounded"
-                   />
-                   <label htmlFor="termsCheckbox" className="text-sm text-gray-700 cursor-pointer">
-                     I agree to the{" "}
-                     <button
-                       type="button"
-                       onClick={(e) => {
-                         e.preventDefault();
-                         setShowTermsModal(true);
-                       }}
-                       className="text-violet-600 hover:text-violet-800 underline font-semibold"
-                     >
-                       Terms of Service
-                     </button>
-                   </label>
-                 </div>
               </div>
             )}
 
@@ -498,12 +470,6 @@ const SignUpPage = () => {
           </form>
         </div>
       </div>
-
-      {/* Terms of Service Modal */}
-      <TermsOfServiceModal
-        isOpen={showTermsModal}
-        onClose={() => setShowTermsModal(false)}
-      />
     </div>
   );
 };

--- a/src/utils/userIdentity.ts
+++ b/src/utils/userIdentity.ts
@@ -1,0 +1,160 @@
+import { supabase } from "../supabase-client";
+
+type UserIdentity = {
+  name: string;
+  email: string;
+  avatar: string | null;
+};
+
+const fallbackNameFor = (userId: string) =>
+  `User ${String(userId).slice(0, 6) || "Unknown"}`;
+
+const normalizeText = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const getFirstTextValueFromObject = (value: unknown): string | null => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  for (const objectValue of Object.values(record)) {
+    const normalized = normalizeText(objectValue);
+    if (normalized) return normalized;
+  }
+  return null;
+};
+
+const getEmailFromRpcResult = (data: unknown): string | null => {
+  if (Array.isArray(data) && data.length > 0) {
+    const first = data[0] as { email?: unknown };
+    return normalizeText(first?.email) || getFirstTextValueFromObject(first);
+  }
+
+  if (typeof data === "object" && data !== null) {
+    const maybeObj = data as { email?: unknown };
+    return normalizeText(maybeObj.email) || getFirstTextValueFromObject(maybeObj);
+  }
+
+  return normalizeText(data);
+};
+
+const getNameFromRpcResult = (data: unknown): string | null => {
+  if (Array.isArray(data) && data.length > 0) {
+    const first = data[0] as { full_name?: unknown; name?: unknown; email?: unknown };
+    return (
+      normalizeText(first?.full_name) ||
+      normalizeText(first?.name) ||
+      normalizeText(first?.email) ||
+      getFirstTextValueFromObject(first) ||
+      normalizeText(data[0])
+    );
+  }
+
+  if (typeof data === "object" && data !== null) {
+    const maybeObj = data as { full_name?: unknown; name?: unknown; email?: unknown };
+    return (
+      normalizeText(maybeObj.full_name) ||
+      normalizeText(maybeObj.name) ||
+      normalizeText(maybeObj.email) ||
+      getFirstTextValueFromObject(maybeObj)
+    );
+  }
+
+  return normalizeText(data);
+};
+
+export const resolveUserIdentity = async (
+  userId: string,
+  fallbackEmail?: string
+): Promise<UserIdentity> => {
+  const fallbackName = normalizeText(fallbackEmail)?.split("@")[0] || fallbackNameFor(userId);
+
+  if (!userId) {
+    return { name: fallbackName, email: normalizeText(fallbackEmail) || "", avatar: null };
+  }
+
+  let email = normalizeText(fallbackEmail) || "";
+  let avatar: string | null = null;
+
+  try {
+    const { data: profileData } = await supabase
+      .from("profiles")
+      .select("full_name, avatar_url")
+      .eq("id", userId)
+      .maybeSingle();
+
+    const profileName = normalizeText(profileData?.full_name);
+    avatar = normalizeText(profileData?.avatar_url) || null;
+    if (profileName) {
+      return { name: profileName, email, avatar };
+    }
+  } catch (error) {
+    console.warn("resolveUserIdentity: profiles lookup failed", error);
+  }
+
+  try {
+    const { data: usersData } = await supabase
+      .from("users")
+      .select("full_name, email")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    const usersName = normalizeText(usersData?.full_name);
+    const usersEmail = normalizeText(usersData?.email);
+    if (usersEmail && !email) email = usersEmail;
+    if (usersName) {
+      return { name: usersName, email, avatar };
+    }
+  } catch (error) {
+    console.warn("resolveUserIdentity: users lookup failed", error);
+  }
+
+  try {
+    const { data: displayNameData, error: displayNameError } = await supabase.rpc(
+      "get_user_display_name",
+      { user_uuid: userId }
+    );
+    if (!displayNameError) {
+      const displayName = getNameFromRpcResult(displayNameData);
+      if (displayName) {
+        return { name: displayName, email, avatar };
+      }
+    }
+  } catch (error) {
+    console.warn("resolveUserIdentity: get_user_display_name RPC failed", error);
+  }
+
+  try {
+    const { data: nameData, error: nameError } = await supabase.rpc("get_user_name", {
+      user_id: userId,
+    });
+    if (!nameError) {
+      const rpcName = getNameFromRpcResult(nameData);
+      if (rpcName) {
+        return { name: rpcName, email, avatar };
+      }
+    }
+  } catch (error) {
+    console.warn("resolveUserIdentity: get_user_name RPC failed", error);
+  }
+
+  try {
+    const { data: emailData, error: emailError } = await supabase.rpc("get_user_email", {
+      user_id: userId,
+    });
+    if (!emailError) {
+      const rpcEmail = getEmailFromRpcResult(emailData);
+      if (rpcEmail) {
+        email = rpcEmail;
+        const emailName = rpcEmail.split("@")[0];
+        return { name: normalizeText(emailName) || fallbackName, email, avatar };
+      }
+    }
+  } catch (error) {
+    console.warn("resolveUserIdentity: get_user_email RPC failed", error);
+  }
+
+  return { name: fallbackName, email, avatar };
+};
+

--- a/supabase/migrations/20260512102500_fix_notifications_delivery.sql
+++ b/supabase/migrations/20260512102500_fix_notifications_delivery.sql
@@ -1,0 +1,53 @@
+ALTER TABLE public.notifications
+ADD COLUMN IF NOT EXISTS read BOOLEAN DEFAULT FALSE;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'notifications'
+      AND column_name = 'is_read'
+  ) THEN
+    UPDATE public.notifications
+    SET read = COALESCE(read, is_read, FALSE);
+  ELSE
+    UPDATE public.notifications
+    SET read = COALESCE(read, FALSE);
+  END IF;
+END $$;
+
+UPDATE public.notifications
+SET read = FALSE
+WHERE read IS NULL;
+
+ALTER TABLE public.notifications
+ALTER COLUMN read SET DEFAULT FALSE;
+
+ALTER TABLE public.notifications
+ALTER COLUMN read SET NOT NULL;
+
+DROP POLICY IF EXISTS "Users can delete their own notifications" ON public.notifications;
+CREATE POLICY "Users can delete their own notifications"
+  ON public.notifications
+  FOR DELETE
+  TO authenticated
+  USING (user_id = auth.uid());
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_publication
+    WHERE pubname = 'supabase_realtime'
+  ) AND NOT EXISTS (
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'notifications'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.notifications;
+  END IF;
+END $$;

--- a/supabase/migrations/20260512110000_fix_post_fk_compatibility.sql
+++ b/supabase/migrations/20260512110000_fix_post_fk_compatibility.sql
@@ -1,0 +1,91 @@
+DO $$
+DECLARE
+  notifications_post_fk TEXT;
+  conversations_post_fk TEXT;
+BEGIN
+  -- notifications.post_id -> prefer public.posts(id), fallback public.post(id)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'notifications'
+      AND column_name = 'post_id'
+  ) THEN
+    SELECT tc.constraint_name
+    INTO notifications_post_fk
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.constraint_schema = kcu.constraint_schema
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'notifications'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND kcu.column_name = 'post_id'
+    LIMIT 1;
+
+    IF notifications_post_fk IS NOT NULL THEN
+      EXECUTE format(
+        'ALTER TABLE public.notifications DROP CONSTRAINT %I',
+        notifications_post_fk
+      );
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'posts'
+    ) THEN
+      ALTER TABLE public.notifications
+      ADD CONSTRAINT notifications_post_id_fkey
+      FOREIGN KEY (post_id) REFERENCES public.posts(id) ON DELETE CASCADE;
+    ELSIF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'post'
+    ) THEN
+      ALTER TABLE public.notifications
+      ADD CONSTRAINT notifications_post_id_fkey
+      FOREIGN KEY (post_id) REFERENCES public.post(id) ON DELETE CASCADE;
+    END IF;
+  END IF;
+
+  -- conversations.post_id -> prefer public.posts(id), fallback public.post(id)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'conversations'
+      AND column_name = 'post_id'
+  ) THEN
+    SELECT tc.constraint_name
+    INTO conversations_post_fk
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+     AND tc.constraint_schema = kcu.constraint_schema
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'conversations'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND kcu.column_name = 'post_id'
+    LIMIT 1;
+
+    IF conversations_post_fk IS NOT NULL THEN
+      EXECUTE format(
+        'ALTER TABLE public.conversations DROP CONSTRAINT %I',
+        conversations_post_fk
+      );
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'posts'
+    ) THEN
+      ALTER TABLE public.conversations
+      ADD CONSTRAINT conversations_post_id_fkey
+      FOREIGN KEY (post_id) REFERENCES public.posts(id) ON DELETE SET NULL;
+    ELSIF EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'post'
+    ) THEN
+      ALTER TABLE public.conversations
+      ADD CONSTRAINT conversations_post_id_fkey
+      FOREIGN KEY (post_id) REFERENCES public.post(id) ON DELETE SET NULL;
+    END IF;
+  END IF;
+END $$;

--- a/supabase/migrations/20260512111000_fix_user_conversation_insert_policy.sql
+++ b/supabase/migrations/20260512111000_fix_user_conversation_insert_policy.sql
@@ -1,0 +1,17 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'user_conversations'
+  ) THEN
+    ALTER TABLE public.user_conversations ENABLE ROW LEVEL SECURITY;
+
+    DROP POLICY IF EXISTS "Users can insert conversation memberships" ON public.user_conversations;
+    CREATE POLICY "Users can insert conversation memberships"
+      ON public.user_conversations
+      FOR INSERT
+      TO authenticated
+      WITH CHECK (true);
+  END IF;
+END $$;

--- a/supabase/migrations/20260512112000_fix_user_name_rpc.sql
+++ b/supabase/migrations/20260512112000_fix_user_name_rpc.sql
@@ -1,0 +1,81 @@
+-- Recreate functions to avoid parameter-name conflicts on existing signatures
+DROP FUNCTION IF EXISTS public.get_user_display_name(UUID);
+DROP FUNCTION IF EXISTS public.get_user_name(UUID);
+DROP FUNCTION IF EXISTS public.get_user_email(UUID);
+
+CREATE OR REPLACE FUNCTION public.get_user_name(user_id UUID)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  resolved_name TEXT;
+BEGIN
+  SELECT NULLIF(TRIM(p.full_name), '')
+  INTO resolved_name
+  FROM public.profiles p
+  WHERE p.id = user_id;
+
+  IF resolved_name IS NOT NULL THEN
+    RETURN resolved_name;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'full_name'
+  ) THEN
+    EXECUTE '
+      SELECT NULLIF(TRIM(full_name), '''')
+      FROM public.users
+      WHERE user_id = $1
+      LIMIT 1
+    '
+    INTO resolved_name
+    USING user_id;
+
+    IF resolved_name IS NOT NULL THEN
+      RETURN resolved_name;
+    END IF;
+  END IF;
+
+  SELECT
+    COALESCE(
+      NULLIF(TRIM(u.raw_user_meta_data->>'full_name'), ''),
+      NULLIF(TRIM(SPLIT_PART(u.email, '@', 1)), ''),
+      NULLIF(TRIM(u.email), '')
+    )
+  INTO resolved_name
+  FROM auth.users u
+  WHERE u.id = user_id;
+
+  RETURN COALESCE(resolved_name, 'User');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_user_display_name(user_uuid UUID)
+RETURNS TEXT
+LANGUAGE SQL
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+  SELECT public.get_user_name(user_uuid);
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_user_email(user_id UUID)
+RETURNS TABLE (email TEXT)
+LANGUAGE SQL
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+  SELECT u.email
+  FROM auth.users u
+  WHERE u.id = user_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_user_name(UUID) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_user_display_name(UUID) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.get_user_email(UUID) TO anon, authenticated, service_role;


### PR DESCRIPTION
Introduce a resolveUserIdentity util and several DB migration scripts to improve compatibility across different schemas. Make notifications more resilient by handling missing columns (read vs is_read), adding fallback insertion when post_id FK causes failures, and centralizing mark-as-read logic; improve real-time channel handling and refreshed fetching when opening the badge. Unify chat/adoption logic: createAdoptionChat now falls back when post_id FK is unavailable and upserts user_conversations to avoid duplicates. Use resolveUserIdentity in AdoptionRequestDetails, PostDetail, ChatPage to reliably resolve display names and emails, simplify name placeholder handling, and reduce reliance on fragile RPC/profile queries. Revise AuthContext upsert/sign-up/sign-in flows to use id column, add RPC fallbacks to ensure profiles/adoption validation persist, and improve error handling. Remove Terms of Service acceptance gating from SignUpPage and update a small service-worker revision string. Adds migrations: fix_notifications_delivery, fix_post_fk_compatibility, fix_user_conversation_insert_policy, fix_user_name_rpc.